### PR TITLE
Fix generation of speedup plots

### DIFF
--- a/pybench.py
+++ b/pybench.py
@@ -634,7 +634,6 @@ class Benchmark(object):
         xticklabels = kwargs.pop('xticklabels', None)
         xvals = kwargs.pop('xvals')
         xvalues = kwargs.pop('xvalues', xvals)
-        offset = np.arange(len(xvals)) + 0.1
         plotstyle = kwargs.pop('plotstyle', self.plotstyle)
         speedup = kwargs.get('speedup', False)
         trendline = kwargs.get('trendline')
@@ -658,6 +657,10 @@ class Benchmark(object):
             gvals = list(gvals)
             for i, s in enumerate(speedup):
                 gvals[i] = filter(lambda x: x != s, gvals[i])
+        if speedup_single:
+            if speedup[0] in xvals:
+                xvals = [i for i in xvals if i not in speedup]
+        offset = np.arange(len(xvals)) + 0.1
         if colors:
             colors = colors[:max(nregions, ngroups)]
         else:


### PR DESCRIPTION
This fixes (actually, should be more correct to say "improve plots generation") the case when the speedup is taken with respect to something on the xaxis:

For example, if `xaxis = ['a', 'b', 'c']`  and  `speedup = ('a')`, then this PR fixes the fact that the `a` values would be in the graph. However this would be useless information, since the yval would be 1 (the speedup of `a` over `a` is 1).

This might sound weird, but the point is that xaxis has to be one of the `parameters` the user specifies. So you really have to cut away the column with respect to which the speedup is measured.
