### PR TITLE
Change storage backend to xray.DataArray

### DIFF
--- a/pybench/__init__.py
+++ b/pybench/__init__.py
@@ -1,0 +1,11 @@
+from os import path
+
+from benchmark import Benchmark, parser, timed  # NOQA: export
+
+# Use README as module documentation
+readme = path.join(path.dirname(__file__), '..', 'README.rst')
+if path.exists(readme):
+    with open(readme) as f:
+        __doc__ = f.read()
+del readme
+del f

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -418,62 +418,28 @@ class Benchmark(object):
         self.data = xray.concat(arrays, pd.Index(labels, name=name))
         return self
 
-    def combine_series(self, series, filename=None, aggregate={}, merge=False):
+    def combine_series(self, series, filename=None):
         """Combine the results of one or more series of benchmarks.
 
         :param series: a dictionary with the series names as keys and the list
             of values defing the series as value.
         :param filename: the basename for the files to combine (defaults to the
             global name property if not given)
-        :param aggregate: dictionary of regions to aggregate where the key is
-            the resulting region and the value is a list of regions to sum
-        :param merge: if set to `True`, the given series is merged with the
-            existing parameter values. The default setting of `False` assumes
-            that all series are added as new parameters.
         """
-        filename = filename or self.name
-        if merge:
-            pkeys, pvals = zip(*sorted(self.params))
-            for k, v in sorted(series):
-                # The key already exists in the params
-                if k in pkeys:
-                    i = pkeys.index(k)
-                    for p in v:
-                        if p not in pvals[i]:
-                            self.params[i][1].append(p)
-                if k not in pkeys:
-                    self.params.append((k, v))
-        else:
-            self.params = self.params + series
-            pkeys, pvals = zip(*sorted(self.params))
-        result = {'name': self.name, 'params': self.params}
-        timings = self.result.get('timings') or {}
-        skeys, svals = zip(*sorted(series))
-        for svalues in product(*svals):
-            suff = '_'.join('%s%s' % (k, v) for k, v in zip(skeys, svalues))
+        # Add the series as additional dimensions to the parameter space
+        self.params.update(series)
+        data = self._init_data()
+
+        filename = filename or self.benchmark
+
+        # Read file for each combination of the series
+        for s in value_combinations(series):
+            suff = '_'.join('%s%s' % (k, v) for k, v in sorted(s.items()))
             fname = '%s_%s' % (filename, suff)
-            try:
-                res = self._read(fname)
-            except IOError:
-                warn("Series not found: " + str(svalues))
-                continue
-            for key in ['description', 'meta', 'regions']:
-                result[key] = res[key]
-            for target, regions in aggregate.items():
-                # FIXME: this won't currently work with a param series
-                if all([r in res['timings'] for r in regions]):
-                    res['timings'][target] = sum(res['timings'][region]
-                                                 for region in regions)
-            if pkeys == skeys:
-                timings[svalues] = res['timings']
-            else:
-                rkeys = zip(*res['params'])[0]
-                for k, v in res['timings'].items():
-                    key = zip(*sorted(zip(rkeys, k) + zip(skeys, svalues)))[1]
-                    timings[key] = v
-        result['timings'] = timings
-        self.result = result
-        return result
+            data.loc[s] = self._read(fname)[fname]
+
+        self.data = data
+        return self
 
     def dataframe(self, **kwargs):
         """Return results as a pandas DataFrame

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -15,6 +15,9 @@ from subprocess import call, check_output, CalledProcessError
 import time
 from warnings import warn
 
+import pandas as pd
+import xray
+
 # Imports for plot, warn if those fail but do not die
 try:
     import matplotlib as mpl
@@ -153,6 +156,16 @@ class Benchmark(object):
         if getenv('PBS_JOBNAME'):
             self.meta['jobname'] = getenv('PBS_JOBNAME')
         self.timings = defaultdict(float)
+        self.data = self._init_data()
+
+    def _init_data(self, params=None):
+        params = dict(params or self.params)
+        # Add the regions as another dimension to the results data
+        params['region'] = self.regions
+        shape = tuple(len(p) for p in params.values())
+        array = np.zeros(shape=shape)
+        array.fill(np.nan)
+        return xray.DataArray(array, coords=params, name=self.benchmark)
 
     @property
     def name(self):

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -15,12 +15,6 @@ from subprocess import call, check_output, CalledProcessError
 import time
 from warnings import warn
 
-# Use README as module documentation
-readme = path.join(path.dirname(__file__), 'README.rst')
-if path.exists(readme):
-    with open(readme) as f:
-        __doc__ = f.read()
-
 # Imports for plot, warn if those fail but do not die
 try:
     import matplotlib as mpl

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -477,24 +477,17 @@ class Benchmark(object):
             * filename: base name of output file
             * dataframe: pandas DataFrame to export (when given, the keyword
               arguments params, regions, skip and timings are ignored)
-            * params: benchmark parameters
             * tabledir: output directory
             * regions: regions to output
-            * timings: benchmark timings
-            * skip: parameters to skip
             * format: comma-separated list of output formats (html, latex, both)
             * precision: precision of floating point values
         """
         if rank > 0:
             return
-        filename = kwargs.pop('filename', self.result['name'])
-        df = kwargs.get('dataframe')
-        if df is None:
-            params = kwargs.pop('params', self.result['params'])
-            regions = kwargs.pop('regions', self.result['regions'])
-            skip = kwargs.pop('skip', [])
-            timings = kwargs.pop('timings', self.result['timings'])
-            df = self.dataframe(params=params, regions=regions, skip=skip, timings=timings)
+        filename = kwargs.pop('filename', self.name)
+        df = kwargs.get('dataframe') or self.data.to_dataframe()
+        if kwargs.get('regions'):
+            df = df[kwargs.get('regions')]
         tabledir = kwargs.pop('tabledir', self.tabledir)
         formats = kwargs.pop('format', 'html').split(',')
         if not path.exists(tabledir):
@@ -511,6 +504,7 @@ class Benchmark(object):
         for fmt in formats:
             with open(path.join(tabledir, "%s.%s" % (filename, fmt)), 'w') as f:
                 f.write(render[fmt](df))
+        return self
 
     def lookup(self, region, params, keyset=()):
         """Retrieve a specific timing from benchmark results

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -435,9 +435,7 @@ class Benchmark(object):
         for s in value_combinations(series):
             suff = '_'.join('%s%s' % (k, v) for k, v in sorted(s.items()))
             fname = '%s_%s' % (filename, suff)
-            for k, v in self._read(fname).variables.items():
-                if isinstance(v, xray.Coordinate):
-                    continue
+            for k, v in self._read(fname).data_vars.items():
                 if k not in self.data:
                     self.data[k] = self._init_data(params=self.params)
                 self.data[k].loc[s] = v.values

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -342,6 +342,15 @@ class Benchmark(object):
         warmups = kwargs.pop('warmups', self.warmups)
         average = kwargs.pop('average', self.average)
 
+        # Check that all params are defined at the benchmark level
+        for param, vals in params.items():
+            if param not in self.params:
+                raise ValueError('Unknown parameter ' + param)
+            for v in vals:
+                if v not in self.params[param]:
+                    raise ValueError('Invalid value %s for parameter %s (valid: %s)' %
+                                     (v, param, self.params[param]))
+
         self.meta['start_time'] = str(datetime.now())
 
         for param in value_combinations(params):

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -447,29 +447,6 @@ class Benchmark(object):
         self.data = data
         return self
 
-    def dataframe(self, **kwargs):
-        """Return results as a pandas DataFrame
-
-        :param kwargs: keyword arguments override values given in the results
-            * params: benchmark parameters
-            * regions: regions to output
-            * timings: benchmark timings
-            * skip: parameters to skip
-        """
-        import pandas as pd
-        params = kwargs.pop('params', self.result['params'])
-        regions = kwargs.pop('regions', self.result['regions'])
-        timings = kwargs.pop('timings', self.result['timings'])
-        skip = kwargs.pop('skip', [])
-
-        pkeys, pvals = zip(*sorted(params))
-        idx = [pkeys.index(s) for s in skip]
-        df = pd.DataFrame([dict(list((pkeys[i], p) for i, p in enumerate(pv)
-                                     if i not in idx) +
-                                list((r, timings[pv][r]) for r in regions))
-                           for pv in product(*pvals)])
-        return df.set_index([p for p in pkeys if p not in skip])
-
     def table(self, **kwargs):
         """Export results as html or latex table (requires pandas).
 

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -375,6 +375,9 @@ class Benchmark(object):
         self.meta['end_time'] = str(datetime.now())
         return self
 
+    def __call__(self, **kwargs):
+        return self.data.loc[kwargs]
+
     def _file(self, filename=None, suffix=None):
         """Return a filepath specified by given `filename` and `suffix`, which
         default to the global name and suffix attributes if not given."""

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -366,11 +366,14 @@ class Benchmark(object):
             # Average over all timings
             if times:
                 for k in self.timings.keys():
-                    if k not in self.data:
-                        self.data[k] = self._init_data(params=params)
-                    self.data[k].loc[param] = average(d[k] for d in times)
+                    self[k].loc[param] = average(d[k] for d in times)
         self.meta['end_time'] = str(datetime.now())
         return self
+
+    def __getitem__(self, region):
+        if region not in self.data:
+            self.data[region] = self._init_data(params=self.params)
+        return self.data[region]
 
     def __call__(self, region, **kwargs):
         return self.data[region].loc[kwargs]
@@ -436,9 +439,7 @@ class Benchmark(object):
             suff = '_'.join('%s%s' % (k, v) for k, v in sorted(s.items()))
             fname = '%s_%s' % (filename, suff)
             for k, v in self._read(fname).data_vars.items():
-                if k not in self.data:
-                    self.data[k] = self._init_data(params=self.params)
-                self.data[k].loc[s] = v.values
+                self[k].loc[s] = v.values
 
         # Re-label coordinates if requested
         for k, v in (coords or {}).items():

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -166,6 +166,8 @@ class Benchmark(object):
     @contextmanager
     def timed_region(self, name, normalize=1.0):
         """A context manger for timing a region of code identified by name."""
+        if name not in self.regions:
+            raise ValueError("%s is not a valid region: %s" % (name, self.regions))
         if name in self.profiles:
             self.profiles[name].enable()
         t_ = self.timer()
@@ -176,6 +178,8 @@ class Benchmark(object):
 
     def register_timing(self, name, value):
         """Register the timing `value` for the region identified by `name`."""
+        if name not in self.regions:
+            raise ValueError("%s is not a valid region: %s" % (name, self.regions))
         self.timings[name] += value
 
     def _args(self, kwargs):

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -521,6 +521,7 @@ class Benchmark(object):
             * timings: benchmark timings
             * skip: parameters to skip
             * format: comma-separated list of output formats (html, latex, both)
+            * precision: precision of floating point values
         """
         if rank > 0:
             return
@@ -536,6 +537,7 @@ class Benchmark(object):
         formats = kwargs.pop('format', 'html').split(',')
         if not path.exists(tabledir):
             makedirs(tabledir)
+        pd.set_option('display.precision', kwargs.pop('precision', 4))
 
         # Reset the index only if it is a MultiIndex
         if hasattr(df.index, 'levels'):

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -418,13 +418,15 @@ class Benchmark(object):
         self.data = xray.concat(arrays, pd.Index(labels, name=name))
         return self
 
-    def combine_series(self, series, filename=None):
+    def combine_series(self, series, filename=None, coords=None):
         """Combine the results of one or more series of benchmarks.
 
         :param series: a dictionary with the series names as keys and the list
             of values defing the series as value.
         :param filename: the basename for the files to combine (defaults to the
             global name property if not given)
+        :param coords: dictionary of coordinate axes to relabel, where the key
+            is the coordinate and the value is the list of new labels
         """
         # Add the series as additional dimensions to the parameter space
         self.params.update(series)
@@ -437,6 +439,10 @@ class Benchmark(object):
             suff = '_'.join('%s%s' % (k, v) for k, v in sorted(s.items()))
             fname = '%s_%s' % (filename, suff)
             data.loc[s] = self._read(fname)[fname]
+
+        # Re-label coordinates if requested
+        for k, v in (coords or {}).items():
+            data.coords[k] = v
 
         self.data = data
         return self

--- a/pybench/benchmark.py
+++ b/pybench/benchmark.py
@@ -298,17 +298,13 @@ class Benchmark(object):
         out = path.join(profiledir, name)
         if rank == 0 and not path.exists(profiledir):
             makedirs(profiledir)
-        if params:
-            pkeys, pvals = zip(*params)
-        else:
-            pkeys, pvals = (), ()
-        for pvalues in product(*pvals):
+        for param in value_combinations(params):
             if rank == 0:
-                print 'Profile', name, 'for parameters', ', '.join('%s=%s' % (k, v) for k, v in zip(pkeys, pvalues))
-            kwargs.update(dict(zip(pkeys, pvalues)))
+                print 'Profile', name, 'for parameters', ', '.join('%s=%s' % (k, v) for k, v in sorted(param.items()))
+            kwargs.update(param)
             # Dry run
             method(**kwargs)
-            suff = '_'.join('%s%s' % (k, v) for k, v in zip(pkeys, pvals))
+            suff = '_'.join('%s%s' % (k, v) for k, v in sorted(param.items()))
             for r in regions:
                 self.profiles[r] = Profile()
             if 'total' in regions:

--- a/pybench/utils.py
+++ b/pybench/utils.py
@@ -1,0 +1,18 @@
+from collections import OrderedDict
+from itertools import product
+
+
+def value_combinations(dct):
+    """Return a list of dictionaries with all combinations of values from
+    dictionary `dct`, where each value is a list. The input ::
+
+        {'a': [1, 2], 'b': [3, 4, 5]}
+
+    yields ::
+
+        [{'a': 1, 'b': 3}, {'a': 1, 'b': 4}, {'a': 1, 'b': 5},
+         {'a': 2, 'b': 3}, {'a': 2, 'b': 4}, {'a': 2, 'b': 5}]
+    """
+    dct = dict(dct)
+    keys = sorted(dct)
+    return [OrderedDict(zip(keys, p)) for p in product(*(dct[k] for k in keys))]

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,4 @@ setup(name='pybench',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
       ],
-      py_modules=['pybench'])
+      packages=['pybench'])

--- a/test_pybench.py
+++ b/test_pybench.py
@@ -1,33 +1,67 @@
-from itertools import product
+import pytest
 
 from pybench import Benchmark
 
 
+class TestBenchmark(Benchmark):
+    params = {'a': range(1, 4), 'b': range(2, 7, 2)}
+    regions = ['total', 'r1', 'r2']
+
+    def test(self, a=None, b=None):
+        with self.timed_region('r1'):
+            pass
+        with self.timed_region('r2'):
+            pass
+
+
 class TimedRegion(Benchmark):
+    regions = ['total', 'stuff']
+
+    def test(self):
+        with self.timed_region('stuff'):
+            pass
+
+
+class InvalidRegion(Benchmark):
     def test(self):
         with self.timed_region('stuff'):
             pass
 
 
 class Parametrized(Benchmark):
-    params = [('a', range(3)), ('b', range(3))]
+    params = {'a': range(3), 'b': range(3)}
 
     def test(self, a=None, b=None):
         pass
 
 
 def test_no_params():
-    assert Benchmark().run(method=lambda: None)['timings']['total'] > 0.0
+    assert Benchmark().run(method=lambda: None)(region='total') > 0.0
 
 
 def test_no_repeats():
-    assert not Benchmark().run(method=lambda: None, repeats=0)['timings']
+    assert all(Benchmark().run(method=lambda: None, repeats=0).data.isnull())
+
+
+def test_invalid_region():
+    with pytest.raises(ValueError):
+        InvalidRegion().run()
+
+
+def test_invalid_param():
+    with pytest.raises(ValueError):
+        Parametrized().run(params={'c': [1]})
+
+
+def test_invalid_param_value():
+    with pytest.raises(ValueError):
+        Parametrized().run(params={'a': [3]})
 
 
 def test_timed_region():
-    result = TimedRegion().run()
-    assert result['timings']['total'] > 0.0
-    assert result['timings']['stuff'] > 0.0
+    bench = TimedRegion().run()
+    assert bench(region='total') > 0.0
+    assert bench(region='stuff') > 0.0
 
 
 def test_save_load(tmpdir):
@@ -38,32 +72,26 @@ def test_save_load(tmpdir):
     TimedRegion().load(d) == result
 
 
-def test_combine_regions(tmpdir):
-    b = TimedRegion()
-    da = tmpdir.join('a').strpath
-    db = tmpdir.join('b').strpath
-    keys = b.run()['timings'].keys()
-    b.save(da)
-    b.save(db)
-    result = TimedRegion().combine({da: 'a', db: 'b'})
-    assert all('a ' + k in result['timings'] for k in keys)
-    assert all('b ' + k in result['timings'] for k in keys)
+def test_combine_arrays(tmpdir):
+    a = TestBenchmark().run()
+    b = TestBenchmark().run()
+    c = TestBenchmark().combine('c', ['a', 'b'], [a.data, b.data])
+    assert 'c' in c.data.coords
+    assert all(c.data.coords['c'] == ['a', 'b'])
+    assert (c(c='a') == a.data).all()
+    assert (c(c='b') == b.data).all()
 
 
 def test_parametrized():
-    result = Parametrized().run()
-    _, pvalues = zip(*result['params'])
-    assert all(result['timings'][p]['total'] > 0.0
-               for p in product(*pvalues))
+    assert (Parametrized().run().data > 0.0).all()
 
 
 def test_combine_parametrized(tmpdir):
-    b = Parametrized()
     da = tmpdir.join('a').strpath
     db = tmpdir.join('b').strpath
-    params = b.run()['timings'].keys()
-    b.save(da)
-    b.save(db)
-    result = Parametrized().combine({da: 'a', db: 'b'})
-    assert all('a total' in result['timings'][p] for p in params)
-    assert all('b total' in result['timings'][p] for p in params)
+    b = Parametrized().run().save(da).save(db)
+    c = Parametrized().combine('c', ['a', 'b'], [da, db])
+    assert 'c' in c.data.coords
+    assert all(c.data.coords['c'] == ['a', 'b'])
+    assert (c(c='a') == b.data).all()
+    assert (c(c='b') == b.data).all()

--- a/test_pybench.py
+++ b/test_pybench.py
@@ -1,5 +1,4 @@
 from itertools import product
-from time import sleep
 
 from pybench import Benchmark
 
@@ -23,17 +22,6 @@ def test_no_params():
 
 def test_no_repeats():
     assert not Benchmark().run(method=lambda: None, repeats=0)['timings']
-
-
-def test_sleep():
-    def myfunc(n, duration):
-        for _ in range(n):
-            sleep(duration)
-    times = Benchmark().run(method=myfunc,
-                            params=[('n', range(3)),
-                                    ('duration', (0.001, 0.002))])
-    for (n, d), t in times['timings'].items():
-        assert abs(n*d - t['total']) < 1e-3
 
 
 def test_timed_region():


### PR DESCRIPTION
Refactor the storage of benchmark results to use [xray](https://xray.readthedocs.org), an N-dimensional array with labelled coordinate axes, like an N-dimensional `pandas.Series`.

DataArrays can be indexed very efficiently and saved to netCDF file.

There are a few issues / differences to the previous dict based storage:
- [ ] DataArray does not support hierarchical metadata
- [x] The coordinate axes need to be known when initialising the DataArray i.e. the regions to time need to be declared upfront.

This is a WIP, not yet ready to merge, but I'd appreciate comments.
